### PR TITLE
Add TwitterRestApiHttpClient to provide wrapper around common HttpClient usage

### DIFF
--- a/src/RestAPI.Tests/RestAPI.Tests.csproj
+++ b/src/RestAPI.Tests/RestAPI.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="FunctionalTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TwitterRestApiHttpClientFunctionalTests.cs" />
+    <Compile Include="UriHelperTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RestAPI\RestAPI.csproj">

--- a/src/RestAPI.Tests/RestAPI.Tests.csproj
+++ b/src/RestAPI.Tests/RestAPI.Tests.csproj
@@ -58,6 +58,7 @@
   <ItemGroup>
     <Compile Include="FunctionalTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TwitterRestApiHttpClientFunctionalTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RestAPI\RestAPI.csproj">
@@ -68,6 +69,9 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />

--- a/src/RestAPI.Tests/TwitterRestApiHttpClientFunctionalTests.cs
+++ b/src/RestAPI.Tests/TwitterRestApiHttpClientFunctionalTests.cs
@@ -70,6 +70,42 @@ namespace RestAPI.Tests
             Assert.IsNotNull(response.users);
         }
 
+        [Test]
+        public async Task GetHttpResponseMessage()
+        {
+            // arrange
+            dynamic parameters = new ExpandoObject();
+            parameters.screen_name = "twitter";
+
+            // sut
+            var client = new TwitterRestApiHttpClient(_authorization);
+
+            var responseMessage = await client.GetHttpResponseMessageAsync(Urls.FriendsList, parameters);
+
+            var responseContent = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            Assert.IsNotNull(responseMessage);
+            Assert.IsNotNull(responseContent);
+        }
+
+        [Test]
+        public async Task GetHttpResponseMessageError()
+        {
+            // arrange
+            dynamic parameters = new ExpandoObject();
+            parameters.screen_name = "!!!";
+
+            // sut
+            var client = new TwitterRestApiHttpClient(_authorization);
+
+            var responseMessage = await client.GetHttpResponseMessageAsync(Urls.FriendsList, parameters);
+
+            var responseContent = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            Assert.IsNotNull(responseMessage);
+            Assert.IsNotNull(responseContent);
+        }
+
         private class TwitterResponseFriendsList
         {
             public string previous_cursor { get; set; }

--- a/src/RestAPI.Tests/TwitterRestApiHttpClientFunctionalTests.cs
+++ b/src/RestAPI.Tests/TwitterRestApiHttpClientFunctionalTests.cs
@@ -1,0 +1,90 @@
+﻿using NUnit.Framework;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Dynamic;
+using System.Threading.Tasks;
+using TwitterOAuth.RestAPI;
+using TwitterOAuth.RestAPI.Models;
+using TwitterOAuth.RestAPI.Resources;
+
+namespace RestAPI.Tests
+{
+    [TestFixture]
+    public class TwitterRestApiHttpClientFunctionalTests
+    {
+        private SecretModel _secretModel;
+        private Authorization _authorization;
+
+        private readonly string _apiKey = ConfigurationManager.AppSettings["ApiKey"];
+        private readonly string _apiSecret = ConfigurationManager.AppSettings["ApiSecret"];
+        private readonly string _accessToken = ConfigurationManager.AppSettings["AccessToken"];
+        private readonly string _accessTokenSecret = ConfigurationManager.AppSettings["AccessTokenSecret"];
+
+        [TestFixtureSetUp]
+        public void Init()
+        {
+            _secretModel = new SecretModel
+            {
+                ApiKey = _apiKey,
+                ApiSecret = _apiSecret,
+                AccessToken = _accessToken,
+                AccessTokenSecret = _accessTokenSecret
+            };
+
+            _authorization = new Authorization(_secretModel);
+        }
+
+        [Test]
+        public async Task GetFriendsListDynamic()
+        {
+            // arrange
+            dynamic parameters = new ExpandoObject();
+            parameters.screen_name = "twitter";
+
+            // sut
+            var client = new TwitterRestApiHttpClient(_authorization);
+
+            // act
+            dynamic response = await client.GetAsync<dynamic>(Urls.FriendsList, parameters);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.users);
+        }
+
+        [Test]
+        [Ignore]
+        // This test is currently failing due to an exception being thrown within NUnit. Therefore it has been ignored.
+        public async Task GetFriendsListTyped()
+        {
+            // arrange
+            dynamic parameters = new ExpandoObject();
+            parameters.screen_name = "twitter";
+
+            // sut
+            var client = new TwitterRestApiHttpClient(_authorization);
+
+            // act
+            TwitterResponseFriendsList response = await client.GetAsync<TwitterResponseFriendsList>(Urls.FriendsList, parameters);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.users);
+        }
+
+        private class TwitterResponseFriendsList
+        {
+            public string previous_cursor { get; set; }
+            public string previous_cursor_str { get; set; }
+            public string next_cursor { get; set; }
+            public string next_cursor_str { get; set; }
+            public List<TwitterUser> users { get; set; }
+        }
+
+        private class TwitterUser
+        {
+            public string id { get; set; }
+            public string name { get; set; }
+            public string screen_name { get; set; }
+            // additional properties included in response are ignored
+        }
+    }
+}

--- a/src/RestAPI.Tests/UriHelperTests.cs
+++ b/src/RestAPI.Tests/UriHelperTests.cs
@@ -1,0 +1,58 @@
+﻿using NUnit.Framework;
+using System.Dynamic;
+using TwitterOAuth.RestAPI.Resources;
+
+namespace RestAPI.Tests
+{
+    [TestFixture]
+    public class UriHelperTests
+    {
+        [Test]
+        public void EnsureProperQueryStringFromDynamic()
+        {
+            // arrange
+            dynamic parameters = new ExpandoObject();
+            parameters.screen_name = "twitter";
+
+            // act
+            var queryString = UriHelper.ConvertDynamicToQueryStringParameters(parameters);
+
+            Assert.AreEqual("screen_name=twitter", queryString);
+
+            // arrange
+            parameters.page = "2";
+            
+            // act
+            queryString = UriHelper.ConvertDynamicToQueryStringParameters(parameters);
+
+            Assert.AreEqual("screen_name=twitter&page=2", queryString);
+        }
+
+        [Test]
+        public void EnsureBlankPropertiesIgnored()
+        {
+            // arrange
+            dynamic parameters = new ExpandoObject();
+            parameters.screen_name = "twitter";
+            parameters.page = "";
+
+            // act
+            var queryString = UriHelper.ConvertDynamicToQueryStringParameters(parameters);
+
+            Assert.AreEqual("screen_name=twitter", queryString);
+        }
+
+        [Test]
+        public void EnsureParametersEscaped()
+        {
+            // arrange
+            dynamic parameters = new ExpandoObject();
+            parameters.screen_name = "twi++er";
+
+            // act
+            var queryString = UriHelper.ConvertDynamicToQueryStringParameters(parameters);
+
+            Assert.AreEqual(@"screen_name=twi%2B%2Ber", queryString);
+        }
+    }
+}

--- a/src/RestAPI/ITwitterRestApiHttpClient.cs
+++ b/src/RestAPI/ITwitterRestApiHttpClient.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TwitterOAuth.RestAPI
+{
+    public interface ITwitterRestApiHttpClient
+    {
+        Task<T> GetAsync<T>(string resourceUri, dynamic parameters);
+    }
+}

--- a/src/RestAPI/ITwitterRestApiHttpClient.cs
+++ b/src/RestAPI/ITwitterRestApiHttpClient.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace TwitterOAuth.RestAPI
@@ -11,5 +8,9 @@ namespace TwitterOAuth.RestAPI
         Task<T> GetAsync<T>(string resourceUri, dynamic parameters);
 
         Task<T> GetAsync<T>(string resourceUri);
+
+        Task<HttpResponseMessage> GetHttpResponseMessageAsync(string resourceUri, dynamic parameters);
+
+        Task<HttpResponseMessage> GetHttpResponseMessageAsync(string resourceUri);
     }
 }

--- a/src/RestAPI/ITwitterRestApiHttpClient.cs
+++ b/src/RestAPI/ITwitterRestApiHttpClient.cs
@@ -9,5 +9,7 @@ namespace TwitterOAuth.RestAPI
     public interface ITwitterRestApiHttpClient
     {
         Task<T> GetAsync<T>(string resourceUri, dynamic parameters);
+
+        Task<T> GetAsync<T>(string resourceUri);
     }
 }

--- a/src/RestAPI/Resources/JsonHelper.cs
+++ b/src/RestAPI/Resources/JsonHelper.cs
@@ -1,0 +1,27 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace TwitterOAuth.RestAPI.Resources
+{
+    public class JsonHelper
+    {
+        public static T ParseResponseContent<T>(string responseContent)
+        {
+            var jToken = JToken.Parse(responseContent);
+            if (jToken.Type == JTokenType.Array)
+            {
+                var jArray = JArray.Parse(responseContent);
+
+                T r = JsonConvert.DeserializeObject<T>(jArray.ToString());
+                return r;
+            }
+            else
+            {
+                var jObject = JObject.Parse(responseContent);
+
+                T r = JsonConvert.DeserializeObject<T>(jObject.ToString());
+                return r;
+            }
+        }
+    }
+}

--- a/src/RestAPI/Resources/UriHelper.cs
+++ b/src/RestAPI/Resources/UriHelper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Routing;
+
+namespace TwitterOAuth.RestAPI.Resources
+{
+    public class UriHelper
+    {
+        public static string ConvertDynamicToQueryStringParameters(dynamic parameters)
+        {
+            var d = new RouteValueDictionary(parameters);
+            var sb = new StringBuilder();
+
+            foreach (var i in d)
+            {
+                sb.AppendFormat("{0}={1}&", i.Key, i.Value);
+            }
+
+            return sb.ToString().TrimEnd('&');
+        }
+    }
+}

--- a/src/RestAPI/Resources/UriHelper.cs
+++ b/src/RestAPI/Resources/UriHelper.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Web.Routing;
 
 namespace TwitterOAuth.RestAPI.Resources
@@ -12,14 +9,19 @@ namespace TwitterOAuth.RestAPI.Resources
         public static string ConvertDynamicToQueryStringParameters(dynamic parameters)
         {
             var d = new RouteValueDictionary(parameters);
-            var sb = new StringBuilder();
 
-            foreach (var i in d)
-            {
-                sb.AppendFormat("{0}={1}&", i.Key, i.Value);
-            }
+            // TODO: support query string array value 
+            var queryString = string.Join("&",
+                from i in d
+                where
+                    !String.IsNullOrWhiteSpace(i.Key)
+                    && (i.Value != null && !String.IsNullOrWhiteSpace(i.Value.ToString()))
+                select
+                    Uri.EscapeDataString(i.Key)
+                    + "="
+                    + Uri.EscapeDataString(i.Value.ToString()));
 
-            return sb.ToString().TrimEnd('&');
+            return queryString;
         }
     }
 }

--- a/src/RestAPI/Resources/UriHelper.cs
+++ b/src/RestAPI/Resources/UriHelper.cs
@@ -23,5 +23,15 @@ namespace TwitterOAuth.RestAPI.Resources
 
             return queryString;
         }
+
+        public static string GetResourceUriWithQueryString(string resourceUri, dynamic parameters)
+        {
+            var queryString = ConvertDynamicToQueryStringParameters(parameters);
+
+            var ub = new UriBuilder(resourceUri);
+            ub.Query = queryString;
+
+            return ub.Uri.AbsoluteUri;
+        }
     }
 }

--- a/src/RestAPI/Resources/Urls.cs
+++ b/src/RestAPI/Resources/Urls.cs
@@ -6,6 +6,7 @@
         public static string UsersLookup = "https://api.twitter.com/1.1/users/lookup.json";
         public static string StatusesUpdate = "https://api.twitter.com/1.1/statuses/update.json";
         public static string FriendsIds = "https://api.twitter.com/1.1/friends/ids.json";
+        public static string FriendsList = "https://api.twitter.com/1.1/friends/list.json";
         public static string FollowersIds = "https://api.twitter.com/1.1/followers/ids.json";
         public static string StatusesMentionsTimeline = "https://api.twitter.com/1.1/statuses/mentions_timeline.json";
     }

--- a/src/RestAPI/RestAPI.csproj
+++ b/src/RestAPI/RestAPI.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Authorization.cs" />
+    <Compile Include="ITwitterRestApiHttpClient.cs" />
     <Compile Include="Models\FollowersIdsModel.cs" />
     <Compile Include="Models\SecretModel.cs" />
     <Compile Include="Models\StatusesUpdateModel.cs" />
@@ -61,6 +62,7 @@
     <Compile Include="Models\Twitter\UserMention.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Urls.cs" />
+    <Compile Include="TwitterRestApiHttpClient.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/RestAPI/RestAPI.csproj
+++ b/src/RestAPI/RestAPI.csproj
@@ -30,6 +30,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
@@ -61,8 +65,13 @@
     <Compile Include="Models\UserLookupModel.cs" />
     <Compile Include="Models\Twitter\UserMention.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Resources\JsonHelper.cs" />
+    <Compile Include="Resources\UriHelper.cs" />
     <Compile Include="Resources\Urls.cs" />
     <Compile Include="TwitterRestApiHttpClient.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/RestAPI/TwitterRestApiHttpClient.cs
+++ b/src/RestAPI/TwitterRestApiHttpClient.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Dynamic;
-using System.Linq;
-using System.Text;
+using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using TwitterOAuth.RestAPI.Resources;
 
 namespace TwitterOAuth.RestAPI
 {
@@ -11,14 +10,65 @@ namespace TwitterOAuth.RestAPI
     {
         private Authorization Authorization { get; set; }
 
+        private HttpClient HttpClient { get; set; }
+
         public TwitterRestApiHttpClient(Authorization authorization)
+            : this(authorization, new HttpClient())
+        {
+            // no-op
+        }
+
+        public TwitterRestApiHttpClient(Authorization authorization, HttpClient httpClient)
         {
             this.Authorization = authorization;
+            this.HttpClient = httpClient;
         }
 
         public async Task<T> GetAsync<T>(string resourceUri, dynamic parameters)
         {
-            throw new NotImplementedException();
+            var queryString = UriHelper.ConvertDynamicToQueryStringParameters(parameters);
+
+            var resourceUriWithQueryString = string.Format("{0}?{1}", resourceUri, queryString);
+
+            return await this.GetAsync<T>(resourceUriWithQueryString);
+        }
+
+        public async Task<T> GetAsync<T>(string resourceUri)
+        {
+            var twitterResponse = await this.GetTwitterResponse(resourceUri);
+
+            if (twitterResponse.HttpResponseMessage.IsSuccessStatusCode)
+            {
+                return JsonHelper.ParseResponseContent<T>(twitterResponse.Content);
+            }
+
+            throw new ApplicationException(string.Format("Received Non Success Status Code. {0} {1}", twitterResponse.HttpResponseMessage.StatusCode, twitterResponse.Content));
+        }
+
+        private async Task<TwitterResponse> GetTwitterResponse(string resourceUri)
+        {
+            var requestUri = new Uri(resourceUri);
+
+            var signedHeader = this.Authorization.GetHeader(requestUri, HttpMethod.Get);
+            
+            this.HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("OAuth", signedHeader);
+
+            var requestMessage = new HttpRequestMessage
+            {
+                RequestUri = requestUri,
+                Method = HttpMethod.Get
+            };
+
+            var responseMessage = await this.HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
+            var responseContent = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            return new TwitterResponse() { HttpResponseMessage = responseMessage, Content = responseContent };
+        }
+        
+        private class TwitterResponse
+        {
+            public HttpResponseMessage HttpResponseMessage { get; set; }
+            public string Content { get; set; }
         }
     }
 }

--- a/src/RestAPI/TwitterRestApiHttpClient.cs
+++ b/src/RestAPI/TwitterRestApiHttpClient.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TwitterOAuth.RestAPI
+{
+    public class TwitterRestApiHttpClient : ITwitterRestApiHttpClient
+    {
+        private Authorization Authorization { get; set; }
+
+        public TwitterRestApiHttpClient(Authorization authorization)
+        {
+            this.Authorization = authorization;
+        }
+
+        public async Task<T> GetAsync<T>(string resourceUri, dynamic parameters)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/RestAPI/TwitterRestApiHttpClient.cs
+++ b/src/RestAPI/TwitterRestApiHttpClient.cs
@@ -14,7 +14,7 @@ namespace TwitterOAuth.RestAPI
         private HttpClient HttpClient { get; set; }
 
         public TwitterRestApiHttpClient(string apiKey, string apiSecret, string accessToken, string accessTokenSecret)
-            : this(new Authorization(new SecretModel() { ApiKey = apiKey, ApiSecret = apiSecret, AccessToken = accessToken, AccessTokenSecret = accessTokenSecret}))
+            : this(new Authorization(new SecretModel() { ApiKey = apiKey, ApiSecret = apiSecret, AccessToken = accessToken, AccessTokenSecret = accessTokenSecret }))
         {
             // no-op
         }
@@ -57,21 +57,20 @@ namespace TwitterOAuth.RestAPI
             var requestUri = new Uri(resourceUri);
 
             var signedHeader = this.Authorization.GetHeader(requestUri, HttpMethod.Get);
-            
-            this.HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("OAuth", signedHeader);
 
             var requestMessage = new HttpRequestMessage
             {
                 RequestUri = requestUri,
                 Method = HttpMethod.Get
             };
+            requestMessage.Headers.Authorization = new AuthenticationHeaderValue("OAuth", signedHeader);
 
             var responseMessage = await this.HttpClient.SendAsync(requestMessage).ConfigureAwait(false);
             var responseContent = await responseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             return new TwitterResponse() { HttpResponseMessage = responseMessage, Content = responseContent };
         }
-        
+
         private class TwitterResponse
         {
             public HttpResponseMessage HttpResponseMessage { get; set; }

--- a/src/RestAPI/TwitterRestApiHttpClient.cs
+++ b/src/RestAPI/TwitterRestApiHttpClient.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
+using TwitterOAuth.RestAPI.Models;
 using TwitterOAuth.RestAPI.Resources;
 
 namespace TwitterOAuth.RestAPI
@@ -11,6 +12,12 @@ namespace TwitterOAuth.RestAPI
         private Authorization Authorization { get; set; }
 
         private HttpClient HttpClient { get; set; }
+
+        public TwitterRestApiHttpClient(string apiKey, string apiSecret, string accessToken, string accessTokenSecret)
+            : this(new Authorization(new SecretModel() { ApiKey = apiKey, ApiSecret = apiSecret, AccessToken = accessToken, AccessTokenSecret = accessTokenSecret}))
+        {
+            // no-op
+        }
 
         public TwitterRestApiHttpClient(Authorization authorization)
             : this(authorization, new HttpClient())

--- a/src/RestAPI/packages.config
+++ b/src/RestAPI/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net451" />
+</packages>


### PR DESCRIPTION
#### Summary

Creates a new TwitterRestApiHttpClient class that provides common usage of HttpClient over Twitter REST API. 
#### Outstanding Questions/Concerns
1. I'm looking for feedback on the naming conventions and patterns I used. Please feel free to modify at will.
2. I am not very familiar with best practices around parsing JSON. I copied the pattern that was previously used in some of the existing functional tests. Will this be adequate?
3. I seem to be running into an issue with NUnit and one of the tests I created. The Test Run ends abruptly when this test is run and an error appears in the Test Explorer window (even when you debug the test as opposed to just running it). I have included the test, but also marked it with `Ignore`.
4. I am also unsure how to handle non success status codes from HttpClient. I'm looking for suggestions there.
5. I added a dependency to JSON.NET. I am unsure of best practices here. Not sure how to specify versions this would be compatible with. Is that in the nuget package settings perhaps?
